### PR TITLE
more intuitive client auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ client = MundiApi::MundiApiClient.new(
 )
 ```
 
+If you are using the new SK standard you can just specify the SK.
+
+ ```ruby
+ # Configuration parameters and credentials
+ secret_key = 'your_secret_key' # Your secret key.
+
+ client = MundiApi::MundiApiClient.new(
+   secret_key: secret_key
+ )
+ ```
+
 The added initlization code can be debugged by putting a breakpoint in the ``` Index ``` method and running the project in debug mode by selecting ``` Run -> Debug 'Development: TestApp' ```.
 
 ![Debug the TestApp](https://apidocs.io/illustration/ruby?step=addCode4&workspaceFolder=MundiAPI-Ruby&workspaceName=MundiApi&projectName=mundi_api&gemName=mundi_api&gemVer=0.16.3&initLine=client%2520%253D%2520MundiApiClient.new%2528%2527basic_auth_user_name%2527%252C%2520%2527basic_auth_password%2527%2529)

--- a/lib/mundi_api/mundi_api_client.rb
+++ b/lib/mundi_api/mundi_api_client.rb
@@ -79,11 +79,12 @@ module MundiApi
     end
 
     # Initializer with authentication and configuration parameters.
-    def initialize(basic_auth_user_name: nil, basic_auth_password: nil)
+    def initialize(basic_auth_user_name: nil, basic_auth_password: nil, secret_key: nil)
       Configuration.basic_auth_user_name = basic_auth_user_name if
         basic_auth_user_name
       Configuration.basic_auth_password = basic_auth_password if
         basic_auth_password
+      Configuration.basic_auth_user_name = secret_key if secret_key
     end
   end
 end


### PR DESCRIPTION
while setting up my API I have noticed that while offered a SK and a PK , I was asked for basic user auth and basic_password when setting up the gem , so after reading the documentation I noticed that only the sk is used as a user identifier on the basic auth.

So in order to make it more obvious for the user I have added the `secret_key` argument at the client initializer, following the most expected naming and added the feature on the README file.